### PR TITLE
access: detect alternative dungeon exits in tracker

### DIFF
--- a/Source/controls/tracker.cpp
+++ b/Source/controls/tracker.cpp
@@ -647,7 +647,7 @@ template <typename Predicate>
 			if (trigger._tmsg != WM_DIABRTNLVL)
 				continue;
 		} else {
-			if (trigger._tmsg != WM_DIABPREVLVL)
+			if (!IsAnyOf(trigger._tmsg, WM_DIABPREVLVL, WM_DIABTWARPUP))
 				continue;
 		}
 
@@ -749,7 +749,7 @@ template <typename Predicate>
 
 	for (int i = 0; i < numtrigs; ++i) {
 		const TriggerStruct &trigger = trigs[i];
-		if (!IsAnyOf(trigger._tmsg, WM_DIABNEXTLVL, WM_DIABPREVLVL))
+		if (!IsAnyOf(trigger._tmsg, WM_DIABNEXTLVL, WM_DIABPREVLVL, WM_DIABTWARPUP))
 			continue;
 
 		const Point triggerPosition { trigger.position.x, trigger.position.y };
@@ -2651,7 +2651,7 @@ void UpdateAutoWalkTracker()
 		const TriggerStruct &trigger = trigs[triggerIndex];
 		const bool valid = leveltype == DTYPE_TOWN
 		    ? IsAnyOf(trigger._tmsg, WM_DIABNEXTLVL, WM_DIABTOWNWARP)
-		    : (setlevel ? trigger._tmsg == WM_DIABRTNLVL : trigger._tmsg == WM_DIABPREVLVL);
+		    : (setlevel ? trigger._tmsg == WM_DIABRTNLVL : IsAnyOf(trigger._tmsg, WM_DIABPREVLVL, WM_DIABTWARPUP));
 		if (!valid) {
 			AutoWalkTrackerTargetId = -1;
 			SpeakText(_("Target entrance is gone."), true);
@@ -2674,7 +2674,7 @@ void UpdateAutoWalkTracker()
 			return;
 		}
 		const TriggerStruct &trigger = trigs[triggerIndex];
-		if (!IsAnyOf(trigger._tmsg, WM_DIABNEXTLVL, WM_DIABPREVLVL)) {
+		if (!IsAnyOf(trigger._tmsg, WM_DIABNEXTLVL, WM_DIABPREVLVL, WM_DIABTWARPUP)) {
 			AutoWalkTrackerTargetId = -1;
 			SpeakText(_("Target stairs are gone."), true);
 			return;


### PR DESCRIPTION
## Summary
- Add `WM_DIABTWARPUP` to trigger message checks in the tracker so the "entrances/exits" and "stairs" categories detect town warps
- Fixes detection of alternative dungeon exits from Catacombs L1, Caves L1, Hell L1, Hive, and Crypt back to town
- Previously only regular stairs up (`WM_DIABPREVLVL`) were detected

## Test plan
- [ ] In Catacombs L1, use tracker entrances/exits category to verify "Warp up" appears as a target
- [ ] Verify auto-walk to the warp works correctly
- [ ] Same for Caves L1, Hell L1, Hive, and Crypt

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)