### PR TITLE
Guard speech-dispatcher shutdown

### DIFF
--- a/Source/utils/screen_reader.cpp
+++ b/Source/utils/screen_reader.cpp
@@ -16,7 +16,7 @@
 namespace devilution {
 
 #if !defined(_WIN32) && !defined(__APPLE__)
-SPDConnection *Speechd;
+SPDConnection *Speechd = nullptr;
 #endif
 
 void InitializeScreenReader()
@@ -37,7 +37,10 @@ void ShutDownScreenReader()
 #elif defined(__APPLE__)
 	osx_shutdown_speech();
 #else
-	spd_close(Speechd);
+	if (Speechd != nullptr) {
+		spd_close(Speechd);
+		Speechd = nullptr;
+	}
 #endif
 }
 
@@ -57,7 +60,8 @@ void SpeakText(std::string_view text, bool force)
 #elif defined(__APPLE__)
 	osx_speak_text(text, force);
 #else
-	spd_say(Speechd, SPD_TEXT, SpokenText.c_str());
+	if (Speechd != nullptr)
+		spd_say(Speechd, SPD_TEXT, SpokenText.c_str());
 #endif
 }
 


### PR DESCRIPTION
## Summary
- Initialize the Linux speech-dispatcher connection pointer to null
- Skip speech-dispatcher shutdown/output calls when initialization did not create a connection

## Why
Running with screen reader support can call shutdown paths even when speech-dispatcher was never opened, such as after printing --version. In that case spd_close() receives an invalid/null connection and can segfault.

## Verification
- Built a Linux Diablo Access 1.4 runtime locally with SCREEN_READER_INTEGRATION=ON
- Reproduced the crash after ./devilutionx-access --version, with gdb showing the segfault in spd_close()
- Verified the guarded build prints DevilutionX v1.4.0 and exits with status 0